### PR TITLE
Dev Command Update, Catch All for Ionic Elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "rm -rf dist && mkdir -p dist && cp -rf node_modules/@ionic/core/dist/ionic dist",
-    "start": "webpack-dev-server --env.NODE_ENV=development",
+    "start": "webpack-dev-server --env.NODE_ENV=development --open",
     "start:prod": "run-s build gzip server",
     "build": "webpack -p",
     "gzip": "find dist -type f | grep -E '.(js|html|css)$' | xargs gzip -kf",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -13,21 +13,7 @@ Vue.use(VueRouter)
 
 Vue.config.productionTip = false;
 
-Vue.config.ignoredElements = [
-  'ion-app',
-  'ion-page',
-  'ion-header',
-  'ion-toolbar',
-  'ion-title',
-  'ion-button',
-  'ion-alert-controller',
-  'ion-content',
-  'ion-list',
-  'ion-list-header',
-  'ion-item',
-  'ion-label',
-  'ion-input',
-];
+Vue.config.ignoredElements = [/^ion-/];
 
 const router = new VueRouter({
   routes: [


### PR DESCRIPTION
- Added `--open` to `dev` npm command to open browser
- Updated `Vue.config.ignoredElements` with a catch all for all ionic elements